### PR TITLE
Add some missing files to the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include tox.ini
+include test/trust*


### PR DESCRIPTION
This commit adds a manifest to make sure that all the files required to run the tests are present in the released tarballs.

---

I'm packaging pew and its dependencies for Fedora. resumable-urlretrieve is one of these dependencies.

Fedora packaging is normally based on released tarballs, and we like to run the tests as part of the build.

With this merged in, the next release would allow just that.
