### PR TITLE
Explicitly require mypy-lang on Python < 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 #! /usr/bin/env python
 
+import sys
 from setuptools import setup # type: ignore
+
+requires = ['requests']
+
+if sys.version_info < (3, 5):
+    requires.append('mypy-lang')
+
 
 setup(
     name='resumable-urlretrieve',
@@ -11,7 +18,7 @@ setup(
     url='https://github.com/berdario/resumable-urlretrieve',
     license='MIT License',
     packages=['resumable'],
-    install_requires=['requests'],
+    install_requires=requires,
     include_package_data=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Over at [Ideascube](https://github.com/ideascube/ideascube) we use resumable-urlretrieve, and our primary target platform is Debian Jessie, which (unfortunately) still runs Python 3.4.

We currently explicitly install mypy-lang in our `requirements.txt` file, but having it handled properly in resumable-urlretrieve means that we could remove it, and others in the same situation as us would benefit. 😃 