### PR TITLE
Run the CI on other Python releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   matrix:
     - TOXENV="py34" PYTHON=3.4.6
     - TOXENV="py35" PYTHON=3.5.3
+    - TOXENV="py36" PYTHON=3.6.0
 
 install:
   - pip install pew

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - HOME=/home/travis
     - WORKON_HOME=$HOME/.pew
   matrix:
-    - TOXENV="py35" PYTHON=3.5.0
+    - TOXENV="py35" PYTHON=3.5.3
 
 install:
   - pip install pew

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - HOME=/home/travis
     - WORKON_HOME=$HOME/.pew
   matrix:
+    - TOXENV="py34" PYTHON=3.4.6
     - TOXENV="py35" PYTHON=3.5.3
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ env:
     - HOME=/home/travis
     - WORKON_HOME=$HOME/.pew
   matrix:
-    - TOXENV="py35"
+    - TOXENV="py35" PYTHON=3.5.0
 
 install:
   - pip install pew
   - mkdir $WORKON_HOME
-  - pew install 3.5.0
-  - pew new -d py35 --python=$(pew locate_python 3.5.0) -i tox -i mypy-lang
+  - pew install $PYTHON
+  - pew new -d py35 --python=$(pew locate_python $PYTHON) -i tox -i mypy-lang
 script: pew in py35 tox -e $TOXENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install:
   - pip install pew
   - mkdir $WORKON_HOME
   - pew install $PYTHON
-  - pew new -d py35 --python=$(pew locate_python $PYTHON) -i tox -i mypy-lang
-script: pew in py35 tox -e $TOXENV
+  - pew new -d venv --python=$(pew locate_python $PYTHON) -i tox -i mypy-lang
+script: pew in venv tox -e $TOXENV

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 #! /usr/bin/env python
 
+import sys
 from setuptools import setup # type: ignore
+
+requires = ['requests']
+
+if sys.version_info < (3, 5):
+    requires.append('typing')
+
 
 setup(
     name='resumable-urlretrieve',
@@ -11,7 +18,7 @@ setup(
     url='https://github.com/berdario/resumable-urlretrieve',
     license='MIT License',
     packages=['resumable'],
-    install_requires=['requests'],
+    install_requires=requires,
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35
+envlist = py34,py35,py36
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35
+envlist = py34,py35
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.6 was released recently, so it's a good idea to test the module on it.

In addition, Python 3.4 is still the system Python release on some popular OS, notably Debian Jessie.

However, resumable-urlretrieve requires the typing module which needs to be explicitly added as a dependency on Python < 3.5.